### PR TITLE
Remove obsoleted explicit file encoding declaration

### DIFF
--- a/src/obfuscapk/.vscode/settings.json
+++ b/src/obfuscapk/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "python.pythonPath": "C:\\Users\\paha0\\AppData\\Local\\Programs\\Python\\Python38\\python.exe"
-}

--- a/src/obfuscapk/.vscode/settings.json
+++ b/src/obfuscapk/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.pythonPath": "C:\\Users\\paha0\\AppData\\Local\\Programs\\Python\\Python38\\python.exe"
+}

--- a/src/obfuscapk/cli.py
+++ b/src/obfuscapk/cli.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3.7
-# coding: utf-8
 
 import argparse
 import logging

--- a/src/obfuscapk/main.py
+++ b/src/obfuscapk/main.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3.7
-# coding: utf-8
 
 import logging
 import os

--- a/src/obfuscapk/obfuscation.py
+++ b/src/obfuscapk/obfuscation.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3.7
-# coding: utf-8
 
 import logging
 import os

--- a/src/obfuscapk/obfuscator_category.py
+++ b/src/obfuscapk/obfuscator_category.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3.7
-# coding: utf-8
 
 from abc import ABC, abstractmethod
 

--- a/src/obfuscapk/obfuscator_manager.py
+++ b/src/obfuscapk/obfuscator_manager.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3.7
-# coding: utf-8
 
 import os
 

--- a/src/obfuscapk/obfuscators/advanced_reflection/__init__.py
+++ b/src/obfuscapk/obfuscators/advanced_reflection/__init__.py
@@ -1,4 +1,3 @@
 #!/usr/bin/env python3.7
-# coding: utf-8
 
 from .advanced_reflection import AdvancedReflection

--- a/src/obfuscapk/obfuscators/advanced_reflection/advanced_reflection.py
+++ b/src/obfuscapk/obfuscators/advanced_reflection/advanced_reflection.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3.7
-# coding: utf-8
 
 import logging
 import os

--- a/src/obfuscapk/obfuscators/arithmetic_branch/__init__.py
+++ b/src/obfuscapk/obfuscators/arithmetic_branch/__init__.py
@@ -1,4 +1,3 @@
 #!/usr/bin/env python3.7
-# coding: utf-8
 
 from .arithmetic_branch import ArithmeticBranch

--- a/src/obfuscapk/obfuscators/arithmetic_branch/arithmetic_branch.py
+++ b/src/obfuscapk/obfuscators/arithmetic_branch/arithmetic_branch.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3.7
-# coding: utf-8
 
 import logging
 

--- a/src/obfuscapk/obfuscators/asset_encryption/__init__.py
+++ b/src/obfuscapk/obfuscators/asset_encryption/__init__.py
@@ -1,4 +1,3 @@
 #!/usr/bin/env python3.7
-# coding: utf-8
 
 from .asset_encryption import AssetEncryption

--- a/src/obfuscapk/obfuscators/asset_encryption/asset_encryption.py
+++ b/src/obfuscapk/obfuscators/asset_encryption/asset_encryption.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3.7
-# coding: utf-8
 
 import logging
 import os

--- a/src/obfuscapk/obfuscators/call_indirection/__init__.py
+++ b/src/obfuscapk/obfuscators/call_indirection/__init__.py
@@ -1,4 +1,3 @@
 #!/usr/bin/env python3.7
-# coding: utf-8
 
 from .call_indirection import CallIndirection

--- a/src/obfuscapk/obfuscators/call_indirection/call_indirection.py
+++ b/src/obfuscapk/obfuscators/call_indirection/call_indirection.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3.7
-# coding: utf-8
 
 import logging
 import re

--- a/src/obfuscapk/obfuscators/class_rename/__init__.py
+++ b/src/obfuscapk/obfuscators/class_rename/__init__.py
@@ -1,4 +1,3 @@
 #!/usr/bin/env python3.7
-# coding: utf-8
 
 from .class_rename import ClassRename

--- a/src/obfuscapk/obfuscators/class_rename/class_rename.py
+++ b/src/obfuscapk/obfuscators/class_rename/class_rename.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3.7
-# coding: utf-8
 
 import logging
 import os

--- a/src/obfuscapk/obfuscators/const_string_encryption/__init__.py
+++ b/src/obfuscapk/obfuscators/const_string_encryption/__init__.py
@@ -1,4 +1,3 @@
 #!/usr/bin/env python3.7
-# coding: utf-8
 
 from .const_string_encryption import ConstStringEncryption

--- a/src/obfuscapk/obfuscators/const_string_encryption/const_string_encryption.py
+++ b/src/obfuscapk/obfuscators/const_string_encryption/const_string_encryption.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3.7
-# coding: utf-8
 
 import logging
 import os

--- a/src/obfuscapk/obfuscators/debug_removal/__init__.py
+++ b/src/obfuscapk/obfuscators/debug_removal/__init__.py
@@ -1,4 +1,3 @@
 #!/usr/bin/env python3.7
-# coding: utf-8
 
 from .debug_removal import DebugRemoval

--- a/src/obfuscapk/obfuscators/debug_removal/debug_removal.py
+++ b/src/obfuscapk/obfuscators/debug_removal/debug_removal.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3.7
-# coding: utf-8
 
 import logging
 import re

--- a/src/obfuscapk/obfuscators/field_rename/__init__.py
+++ b/src/obfuscapk/obfuscators/field_rename/__init__.py
@@ -1,4 +1,3 @@
 #!/usr/bin/env python3.7
-# coding: utf-8
 
 from .field_rename import FieldRename

--- a/src/obfuscapk/obfuscators/field_rename/field_rename.py
+++ b/src/obfuscapk/obfuscators/field_rename/field_rename.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3.7
-# coding: utf-8
 
 import logging
 from typing import List, Set

--- a/src/obfuscapk/obfuscators/goto/__init__.py
+++ b/src/obfuscapk/obfuscators/goto/__init__.py
@@ -1,4 +1,3 @@
 #!/usr/bin/env python3.7
-# coding: utf-8
 
 from .goto import Goto

--- a/src/obfuscapk/obfuscators/goto/goto.py
+++ b/src/obfuscapk/obfuscators/goto/goto.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3.7
-# coding: utf-8
 
 import logging
 

--- a/src/obfuscapk/obfuscators/lib_encryption/__init__.py
+++ b/src/obfuscapk/obfuscators/lib_encryption/__init__.py
@@ -1,4 +1,3 @@
 #!/usr/bin/env python3.7
-# coding: utf-8
 
 from .lib_encryption import LibEncryption

--- a/src/obfuscapk/obfuscators/lib_encryption/lib_encryption.py
+++ b/src/obfuscapk/obfuscators/lib_encryption/lib_encryption.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3.7
-# coding: utf-8
 
 import logging
 import os

--- a/src/obfuscapk/obfuscators/method_overload/__init__.py
+++ b/src/obfuscapk/obfuscators/method_overload/__init__.py
@@ -1,4 +1,3 @@
 #!/usr/bin/env python3.7
-# coding: utf-8
 
 from .method_overload import MethodOverload

--- a/src/obfuscapk/obfuscators/method_overload/method_overload.py
+++ b/src/obfuscapk/obfuscators/method_overload/method_overload.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3.7
-# coding: utf-8
 
 import logging
 import random

--- a/src/obfuscapk/obfuscators/method_rename/__init__.py
+++ b/src/obfuscapk/obfuscators/method_rename/__init__.py
@@ -1,4 +1,3 @@
 #!/usr/bin/env python3.7
-# coding: utf-8
 
 from .method_rename import MethodRename

--- a/src/obfuscapk/obfuscators/method_rename/method_rename.py
+++ b/src/obfuscapk/obfuscators/method_rename/method_rename.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3.7
-# coding: utf-8
 
 import logging
 from typing import List, Set

--- a/src/obfuscapk/obfuscators/new_alignment/__init__.py
+++ b/src/obfuscapk/obfuscators/new_alignment/__init__.py
@@ -1,4 +1,3 @@
 #!/usr/bin/env python3.7
-# coding: utf-8
 
 from .new_alignment import NewAlignment

--- a/src/obfuscapk/obfuscators/new_alignment/new_alignment.py
+++ b/src/obfuscapk/obfuscators/new_alignment/new_alignment.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3.7
-# coding: utf-8
 
 import logging
 

--- a/src/obfuscapk/obfuscators/new_signature/__init__.py
+++ b/src/obfuscapk/obfuscators/new_signature/__init__.py
@@ -1,4 +1,3 @@
 #!/usr/bin/env python3.7
-# coding: utf-8
 
 from .new_signature import NewSignature

--- a/src/obfuscapk/obfuscators/new_signature/new_signature.py
+++ b/src/obfuscapk/obfuscators/new_signature/new_signature.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3.7
-# coding: utf-8
 
 import logging
 

--- a/src/obfuscapk/obfuscators/nop/__init__.py
+++ b/src/obfuscapk/obfuscators/nop/__init__.py
@@ -1,4 +1,3 @@
 #!/usr/bin/env python3.7
-# coding: utf-8
 
 from .nop import Nop

--- a/src/obfuscapk/obfuscators/nop/nop.py
+++ b/src/obfuscapk/obfuscators/nop/nop.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3.7
-# coding: utf-8
 
 import logging
 import re

--- a/src/obfuscapk/obfuscators/random_manifest/__init__.py
+++ b/src/obfuscapk/obfuscators/random_manifest/__init__.py
@@ -1,4 +1,3 @@
 #!/usr/bin/env python3.7
-# coding: utf-8
 
 from .random_manifest import RandomManifest

--- a/src/obfuscapk/obfuscators/random_manifest/random_manifest.py
+++ b/src/obfuscapk/obfuscators/random_manifest/random_manifest.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3.7
-# coding: utf-8
 
 import logging
 import random

--- a/src/obfuscapk/obfuscators/rebuild/__init__.py
+++ b/src/obfuscapk/obfuscators/rebuild/__init__.py
@@ -1,4 +1,3 @@
 #!/usr/bin/env python3.7
-# coding: utf-8
 
 from .rebuild import Rebuild

--- a/src/obfuscapk/obfuscators/rebuild/rebuild.py
+++ b/src/obfuscapk/obfuscators/rebuild/rebuild.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3.7
-# coding: utf-8
 
 import logging
 

--- a/src/obfuscapk/obfuscators/reflection/__init__.py
+++ b/src/obfuscapk/obfuscators/reflection/__init__.py
@@ -1,4 +1,3 @@
 #!/usr/bin/env python3.7
-# coding: utf-8
 
 from .reflection import Reflection

--- a/src/obfuscapk/obfuscators/reflection/reflection.py
+++ b/src/obfuscapk/obfuscators/reflection/reflection.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3.7
-# coding: utf-8
 
 import logging
 import os

--- a/src/obfuscapk/obfuscators/reorder/__init__.py
+++ b/src/obfuscapk/obfuscators/reorder/__init__.py
@@ -1,4 +1,3 @@
 #!/usr/bin/env python3.7
-# coding: utf-8
 
 from .reorder import Reorder

--- a/src/obfuscapk/obfuscators/reorder/reorder.py
+++ b/src/obfuscapk/obfuscators/reorder/reorder.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3.7
-# coding: utf-8
 
 import logging
 import random

--- a/src/obfuscapk/obfuscators/res_string_encryption/__init__.py
+++ b/src/obfuscapk/obfuscators/res_string_encryption/__init__.py
@@ -1,4 +1,3 @@
 #!/usr/bin/env python3.7
-# coding: utf-8
 
 from .res_string_encryption import ResStringEncryption

--- a/src/obfuscapk/obfuscators/res_string_encryption/res_string_encryption.py
+++ b/src/obfuscapk/obfuscators/res_string_encryption/res_string_encryption.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3.7
-# coding: utf-8
 
 import logging
 import os

--- a/src/obfuscapk/obfuscators/virus_total/__init__.py
+++ b/src/obfuscapk/obfuscators/virus_total/__init__.py
@@ -1,4 +1,3 @@
 #!/usr/bin/env python3.7
-# coding: utf-8
 
 from .virus_total import VirusTotal

--- a/src/obfuscapk/obfuscators/virus_total/virus_total.py
+++ b/src/obfuscapk/obfuscators/virus_total/virus_total.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3.7
-# coding: utf-8
 
 import json
 import logging

--- a/src/obfuscapk/tool.py
+++ b/src/obfuscapk/tool.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3.7
-# coding: utf-8
 
 import io
 import logging

--- a/src/obfuscapk/util.py
+++ b/src/obfuscapk/util.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3.7
-# coding: utf-8
 
 import itertools
 import logging


### PR DESCRIPTION
Python 3.7 interpreter treats all source code files as utf-8 by default. 