### PR TITLE
Issue #60 + fix obfuscation res/xml folder

### DIFF
--- a/src/obfuscapk/obfuscators/class_rename/class_rename.py
+++ b/src/obfuscapk/obfuscators/class_rename/class_rename.py
@@ -51,10 +51,9 @@ class ClassRename(obfuscator_category.IRenameObfuscator):
         return dot_rename_transformations
 
     def transform_package_name(self, manifest_xml_root: Element):
-        # self.encrypted_package_name = ".".join(
-        #     [self.encrypt_identifier(token) for token in self.package_name.split(".")]
-        # )
-        self.encrypted_package_name = self.package_name
+        self.encrypted_package_name = ".".join(
+            [self.encrypt_identifier(token) for token in self.package_name.split(".")]
+        )
         
         # Rename package name in manifest file.
         manifest_xml_root.set("package", self.encrypted_package_name)

--- a/src/obfuscapk/obfuscators/class_rename/class_rename.py
+++ b/src/obfuscapk/obfuscators/class_rename/class_rename.py
@@ -51,10 +51,11 @@ class ClassRename(obfuscator_category.IRenameObfuscator):
         return dot_rename_transformations
 
     def transform_package_name(self, manifest_xml_root: Element):
-        self.encrypted_package_name = ".".join(
-            [self.encrypt_identifier(token) for token in self.package_name.split(".")]
-        )
-
+        # self.encrypted_package_name = ".".join(
+        #     [self.encrypt_identifier(token) for token in self.package_name.split(".")]
+        # )
+        self.encrypted_package_name = self.package_name
+        
         # Rename package name in manifest file.
         manifest_xml_root.set("package", self.encrypted_package_name)
         manifest_xml_root.set(
@@ -314,7 +315,7 @@ class ClassRename(obfuscator_category.IRenameObfuscator):
                     obfuscation_info.get_resource_directory()
                 )
                 for file_name in file_names
-                if file_name.endswith(".xml") and "layout" in root  # Only layout files.
+                if file_name.endswith(".xml") and ("layout" in root or "xml" in root)  # Only res/layout-*/ and res/xml-*/ folders.
             )
             xml_files.add(obfuscation_info.get_manifest_file())
 

--- a/src/obfuscapk/obfuscators/method_rename/method_rename.py
+++ b/src/obfuscapk/obfuscators/method_rename/method_rename.py
@@ -166,6 +166,7 @@ class MethodRename(obfuscator_category.IRenameObfuscator):
         smali_files: List[str],
         methods_to_rename: Set[str],
         android_class_names: Set[str],
+        classes_to_ignore: List[str],
         interactive: bool = False,
     ):
         for smali_file in util.show_list_progress(
@@ -192,6 +193,7 @@ class MethodRename(obfuscator_category.IRenameObfuscator):
                             ("direct" in invoke_type or "static" in invoke_type)
                             and method in methods_to_rename
                             and class_name not in android_class_names
+                            and not any(cls in class_name for cls in classes_to_ignore)
                         ):
                             method_name = invoke_match.group("invoke_method")
                             out_file.write(
@@ -233,7 +235,8 @@ class MethodRename(obfuscator_category.IRenameObfuscator):
                 obfuscation_info.get_smali_files(),
                 renamed_methods,
                 android_class_names,
-                obfuscation_info.interactive,
+                util.get_libs_to_ignore(),
+                obfuscation_info.interactive
             )
 
         except Exception as e:


### PR DESCRIPTION
1. Method invocations of ignored classes are no longer obfuscated (at some points this caused a crash, issue #60)
2. When obfuscating, you need to consider the xml folder because it sometimes uses custom views that were obfuscated in smali and layout, but were not affected in the xml folder.