### PR TITLE
Add an option to ignore user defined packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,11 +299,11 @@ is used for the signing operations.
 package names to be ignored.
 All the classes inside those packages will not be obfuscated when this option is used.
 The file should have one package name per line as shown in the example below.
-`ignore_txt file` contents: 
-```
-com.mycompany.dontobfuscate
-com.mycompany.ignore
-```
+`ignore.txt` file contents:
+    ```Object
+    com.mycompany.dontobfuscate
+    com.mycompany.ignore
+    ``` 
 
 Let's consider now a simple working example to see how Obfuscapk works:
 

--- a/README.md
+++ b/README.md
@@ -295,6 +295,16 @@ By default (when `--keystore-file` is not specified), a
 [keystore bundled with Obfuscapk](https://github.com/ClaudiuGeorgiu/Obfuscapk/blob/master/src/obfuscapk/resources/obfuscation_keystore.jks)
 is used for the signing operations.
 
+* `---ignore-packages-file IGNORE_PACKAGES_FILE` is a path to a file which includes 
+package names to be ignored.
+All the classes inside those packages will not be obfuscated when this option is used.
+The file should have one package name per line as shown in the example below.
+`ignore_txt file` contents: 
+```
+com.mycompany.dontobfuscate
+com.mycompany.ignore
+```
+
 Let's consider now a simple working example to see how Obfuscapk works:
 
 ```Shell

--- a/src/obfuscapk/cli.py
+++ b/src/obfuscapk/cli.py
@@ -108,6 +108,13 @@ def get_cmd_args(args: list = None):
         help="The key password for signing the obfuscated .apk file (needed only when "
         "specifying a custom keystore file)",
     )
+    parser.add_argument(
+        "--ignore-packages-file",
+        type=str,
+        metavar="IGNORE_PACKAGES_FILE",
+        help="The file including package names to be ignored "
+             "(one package name per line)",
+    )
     return parser.parse_args(args)
 
 
@@ -158,6 +165,9 @@ def main():
     if arguments.key_password:
         arguments.key_password = arguments.key_password.strip(" '\"")
 
+    if arguments.ignore_packages_file:
+        arguments.ignore_packages_file = arguments.ignore_packages_file.strip(" \"")
+
     perform_obfuscation(
         arguments.apk_file,
         arguments.obfuscator,
@@ -170,6 +180,7 @@ def main():
         arguments.keystore_password,
         arguments.key_alias,
         arguments.key_password,
+        arguments.ignore_packages_file
     )
 
 

--- a/src/obfuscapk/main.py
+++ b/src/obfuscapk/main.py
@@ -54,6 +54,7 @@ def perform_obfuscation(
     keystore_password: str = None,
     key_alias: str = None,
     key_password: str = None,
+    ignore_packages_file: str = None
 ):
     """
     Apply the obfuscation techniques to an input application and generate an obfuscated
@@ -84,6 +85,8 @@ def perform_obfuscation(
     :param key_password: The key password for signing the resulting obfuscated
                          application (needed only when specifying a custom keystore
                          file).
+    :param ignore_packages_file: "The file including package names to be ignored
+                                 (one package name per line)
     """
 
     check_external_tool_dependencies()
@@ -105,6 +108,7 @@ def perform_obfuscation(
         keystore_password,
         key_alias,
         key_password,
+        ignore_packages_file
     )
 
     manager = ObfuscatorManager()

--- a/src/obfuscapk/obfuscation.py
+++ b/src/obfuscapk/obfuscation.py
@@ -29,6 +29,7 @@ class Obfuscation(object):
         keystore_password: str = None,
         key_alias: str = None,
         key_password: str = None,
+        ignore_packages_file: str = None
     ):
         self.logger = logging.getLogger(__name__)
 
@@ -42,6 +43,7 @@ class Obfuscation(object):
         self.keystore_password: str = keystore_password
         self.key_alias: str = key_alias
         self.key_password: str = key_password
+        self.ignore_packages_file: str = ignore_packages_file
 
         # Random string (32 chars long) generation with ASCII letters and digits
         self.encryption_secret = "".join(
@@ -610,3 +612,12 @@ class Obfuscation(object):
 
         # '.join(x, "")' is used to add a trailing slash.
         return os.path.join(self._decoded_apk_path, "res", "")
+
+    def get_ignore_package_names(self) -> List[str]:
+        ignore_package_list = []
+
+        # normalize package names into smali format
+        for item in util.get_non_empty_lines_from_file(os.path.join(self.ignore_packages_file)):
+            ignore_package_list.append("L{0}".format(item))
+
+        return ignore_package_list

--- a/src/obfuscapk/obfuscation.py
+++ b/src/obfuscapk/obfuscation.py
@@ -616,8 +616,11 @@ class Obfuscation(object):
     def get_ignore_package_names(self) -> List[str]:
         ignore_package_list = []
 
+        if self.ignore_packages_file is None:
+            return ignore_package_list
+
         # normalize package names into smali format
         for item in util.get_non_empty_lines_from_file(os.path.join(self.ignore_packages_file)):
-            ignore_package_list.append("L{0}".format(item))
+            ignore_package_list.append("L{0}".format(item).replace('.', '/'))
 
         return ignore_package_list

--- a/src/obfuscapk/obfuscators/class_rename/class_rename.py
+++ b/src/obfuscapk/obfuscators/class_rename/class_rename.py
@@ -29,6 +29,7 @@ class ClassRename(obfuscator_category.IRenameObfuscator):
 
         self.package_name: Union[str, None] = None
         self.encrypted_package_name: Union[str, None] = None
+        self.ignore_package_names = []
 
         # Will be populated before running the class rename obfuscator.
         self.class_name_to_smali_file: dict = {}
@@ -90,6 +91,8 @@ class ClassRename(obfuscator_category.IRenameObfuscator):
                         if class_match:
                             class_name = class_match.group("class_name")
 
+                            ignore_class = class_name.startswith(tuple(self.ignore_package_names))
+
                             # Split class name to its components and encrypt them.
                             class_tokens = self.split_class_pattern.split(
                                 class_name[1:-1]
@@ -105,7 +108,7 @@ class ClassRename(obfuscator_category.IRenameObfuscator):
                                     encrypted_class_name += (
                                         token + class_name[separator_index]
                                     )
-                                elif not r_class:
+                                elif not r_class and not ignore_class:
                                     encrypted_class_name += (
                                         self.encrypt_identifier(token)
                                         + class_name[separator_index]
@@ -334,6 +337,9 @@ class ClassRename(obfuscator_category.IRenameObfuscator):
             # class_rename_transformations = self.rename_class_declarations(
             #     list(package_smali_files), obfuscation_info.interactive
             # )
+
+            # Get user defined ignore package list
+            self.ignore_package_names = obfuscation_info.get_ignore_package_names()
 
             # Rename all classes declared in smali files.
             class_rename_transformations = self.rename_class_declarations(

--- a/src/obfuscapk/obfuscators/field_rename/field_rename.py
+++ b/src/obfuscapk/obfuscators/field_rename/field_rename.py
@@ -55,8 +55,8 @@ class FieldRename(obfuscator_category.IRenameObfuscator):
             description="Renaming field declarations",
         ):
             with util.inplace_edit_file(smali_file) as (in_file, out_file):
+                class_name = None
                 for line in in_file:
-
                     ignore = False
 
                     if not class_name:

--- a/src/obfuscapk/obfuscators/field_rename/field_rename.py
+++ b/src/obfuscapk/obfuscators/field_rename/field_rename.py
@@ -15,6 +15,8 @@ class FieldRename(obfuscator_category.IRenameObfuscator):
         )
         super().__init__()
 
+        self.ignore_package_names = []
+
         self.is_adding_fields = True
 
         self.max_fields_to_add = 0
@@ -54,13 +56,24 @@ class FieldRename(obfuscator_category.IRenameObfuscator):
         ):
             with util.inplace_edit_file(smali_file) as (in_file, out_file):
                 for line in in_file:
+
+                    ignore = False
+
+                    if not class_name:
+                        class_match = util.class_pattern.match(line)
+                        if class_match:
+                            class_name = class_match.group('class_name')
+
                     # Field declared in class.
                     field_match = util.field_pattern.match(line)
 
+                    if class_name.startswith(tuple(self.ignore_package_names)):
+                        ignore = True
+
                     if field_match:
                         field_name = field_match.group("field_name")
-                        # Avoid sub-fields.
-                        if "$" not in field_name:
+                        # Avoid sub-fields and user defined packages.
+                        if not ignore and "$" not in field_name:
                             # Rename field declaration (usages of this field will be
                             # renamed later) and add some random fields.
                             line = line.replace(
@@ -134,6 +147,9 @@ class FieldRename(obfuscator_category.IRenameObfuscator):
 
     def obfuscate(self, obfuscation_info: Obfuscation):
         self.logger.info('Running "{0}" obfuscator'.format(self.__class__.__name__))
+
+        # Get user defined ignore package list
+        self.ignore_package_names = obfuscation_info.get_ignore_package_names()
 
         try:
             sdk_class_declarations = self.get_sdk_class_names(

--- a/src/obfuscapk/obfuscators/method_rename/method_rename.py
+++ b/src/obfuscapk/obfuscators/method_rename/method_rename.py
@@ -15,6 +15,8 @@ class MethodRename(obfuscator_category.IRenameObfuscator):
         )
         super().__init__()
 
+        self.ignore_package_names = []
+
     def rename_method(self, method_name: str) -> str:
         method_md5 = util.get_string_md5(method_name)
         return "m{0}".format(method_md5.lower()[:8])
@@ -52,7 +54,7 @@ class MethodRename(obfuscator_category.IRenameObfuscator):
                             continue
                         elif class_match:
                             class_name = class_match.group("class_name")
-                            if class_name in class_names_to_ignore:
+                            if class_name in class_names_to_ignore or class_name.startswith(tuple(self.ignore_package_names)):
                                 # The methods of this class should be ignored when
                                 # renaming, so proceed with the next class.
                                 skip_remaining_lines = True
@@ -151,6 +153,9 @@ class MethodRename(obfuscator_category.IRenameObfuscator):
 
     def obfuscate(self, obfuscation_info: Obfuscation):
         self.logger.info('Running "{0}" obfuscator'.format(self.__class__.__name__))
+
+        # Get user defined ignore package list
+        self.ignore_package_names = obfuscation_info.get_ignore_package_names()
 
         try:
             # NOTE: only direct methods (methods that are by nature non-overridable,


### PR DESCRIPTION
Hi, thanks  for the nice work. I would like to contribute to the project.

**Problem**: Some developer defined classes may need to be ignored when obfuscating. For example, the class needs to be left untouched when it is used for marshalling. 

**Solution**: Adding an option to ignore user defined packages is needed.

Current commit adds an option to take a file, which lists packages to ignore,  as a parameter. For example, if the file lists these package names
```
tech.ibrokhimov.dontobfuscate
tech.ibrokhimov.ignore
```
Obfuscapk ignores all the classes inside those packages. This is effective for field, class, and method rename options.