### PR TITLE
const_string_encryption: Fix problem where static constructor not correctly found

### DIFF
--- a/src/obfuscapk/obfuscators/const_string_encryption/const_string_encryption.py
+++ b/src/obfuscapk/obfuscators/const_string_encryption/const_string_encryption.py
@@ -110,7 +110,7 @@ class ConstStringEncryption(obfuscator_category.IEncryptionObfuscator):
                         direct_methods_line = line_number
                         continue
 
-                    if line.startswith(".method static constructor <clinit>()V"):
+                    if line.startswith(".method") and line.strip().endswith("static constructor <clinit>()V"):
                         static_constructor_line = line_number
                         continue
 


### PR DESCRIPTION
The current code expects that static constructors are declared as:

.method static constructor <clinit>()V

However, static constructors in smali files may contain the "public" keyword
so the static constructor has the form:

.method public static constructor <clinit>()V

The current code doesn't find such constructors and inserts another
static constructor to the code instead so there are 2 static constructors.
Smali seems to use only the first declared constructor (with the string
initializers) and ignores the second one with the original initialization
code which leads to uninitialized static members.

This patch simply relaxes the check of static constructors so there
can be an arbitrary string (including empty string) between ".method"
and "static".
