### PR TITLE
fix: sign aab bundle with custom keystore

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ feature, download the latest version of BundleDecompiler available from
 save it as `BundleDecompiler.jar` in a directory included in `PATH` (e.g., in Ubuntu,
 `/usr/local/bin` or `/usr/bin`) and make sure it has the executable flag set.
 
+If you want to resign .aab application with your custom keys you need to download [aabresguard](https://github.com/kaedea/aab-signer/tree/master/dist) and save it as `aabresguard.jar` in a directory included in `PATH` (e.g., in Ubuntu,
+`/usr/local/bin` or `/usr/bin`) and make sure it has the executable flag set.
+
 `NOTE:` BundleDecompiler doesn't work on Windows yet, so app bundle obfuscation is not
 supported by Obfuscapk on Windows platform. Also, app bundle support is still in early
 development, so if you faced any problems or if you want to help us improve, please see

--- a/src/obfuscapk/obfuscation.py
+++ b/src/obfuscapk/obfuscation.py
@@ -594,6 +594,10 @@ class Obfuscation(object):
             if self.is_bundle:
                 aabsigner.sign(
                     self.obfuscated_apk_path,
+                    self.keystore_file,
+                    self.keystore_password,
+                    self.key_alias,
+                    self.key_password,
                 )
             else:
                 apksigner.resign(

--- a/src/obfuscapk/toolbundledecompiler.py
+++ b/src/obfuscapk/toolbundledecompiler.py
@@ -219,10 +219,13 @@ class AABSigner(object):
             )
             return
 
-        if "BUNDLE_DECOMPILER_PATH" in os.environ:
-            self.aabsigner_path: str = os.environ["BUNDLE_DECOMPILER_PATH"]
+
+        if "BUNDLE_SIGNER_PATH" in os.environ:
+            self.aabsigner_path: str = os.environ["BUNDLE_SIGNER_PATH"]
         else:
-            self.aabsigner_path: str = "BundleDecompiler.jar"
+            self.aabsigner_path: str = "aabresguard.jar"
+        #download from here:https://github.com/kaedea/aab-signer/tree/master/dist
+        #rename to aabresguard.jar and move it to /use/local/bin/
 
         full_aabsigner_path = shutil.which(self.aabsigner_path)
 
@@ -238,6 +241,10 @@ class AABSigner(object):
     def sign(
         self,
         aab_path: str,
+        keystore_file: str,
+        keystore_password: str,
+        key_alias: str,
+        key_password: str,
     ) -> str:
         if platform.system() == "Windows":
             raise NotImplementedError(
@@ -253,9 +260,13 @@ class AABSigner(object):
             "java",
             "-jar",
             self.aabsigner_path,
-            "sign-bundle",
-            "--in=" + aab_path,
-            "--out=" + aab_path.replace(".aab", "_signed.aab"),
+            "sign-aab",
+            "--bundle=" + aab_path,
+            "--output=" + aab_path.replace(".aab", "_signed.aab"),
+            "--storeFile=" + keystore_file,
+            "--storePassword=" + keystore_password,
+            "--keyAlias=" + key_alias,
+            "--keyPassword=" + key_password
         ]
 
         try:


### PR DESCRIPTION
This pull request fixes the bug of aabsigner for signing the .aab bundle with custom keystore file.

described bug in this issue: https://github.com/ClaudiuGeorgiu/Obfuscapk/issues/168